### PR TITLE
fix: scopes args file

### DIFF
--- a/buf/internal/plugin.bzl
+++ b/buf/internal/plugin.bzl
@@ -53,7 +53,7 @@ def protoc_plugin_test(ctx, proto_infos, protoc, plugin, config, files_to_includ
     args.add_joined(["--buf-plugin_out", "."], join_with = "=")
     args.add_all(sources)
 
-    args_file = ctx.actions.declare_file("args")
+    args_file = ctx.actions.declare_file("{}-args".format(ctx.label.name))
     ctx.actions.write(
         output = args_file,
         content = args,


### PR DESCRIPTION
This PR changes the proto plugin to take into account the name of target
being built to generate the args file. Before this patch, the rules that
use the plugin will generate clashing args files (`path/to/rule/args`).
This is fine if you run only one test at a time, but if you happen to
have a `_lint` and a `_breaking` test in the same bazel package, an
error pops up because both targets are trying to execute actions writing
the same file.
