### PR TITLE
Support `--error-format`

### DIFF
--- a/buf/internal/breaking.bzl
+++ b/buf/internal/breaking.bzl
@@ -32,6 +32,7 @@ def _buf_breaking_test_impl(ctx):
         "limit_to_input_files": ctx.attr.limit_to_input_files,
         "exclude_imports": ctx.attr.exclude_imports,
         "input_config": ctx.file.config.short_path,
+        "error_format": ctx.attr.error_format,
     })
     files_to_include = [ctx.file.against]
     if ctx.file.config != None:
@@ -74,6 +75,10 @@ buf_breaking_test = rule(
         "exclude_imports": attr.bool(
             default = True,
             doc = """Checks are limited to the source files excluding imports from breaking change detection. Please refer to https://docs.buf.build/breaking/protoc-plugin for more details""",
+        ),
+        "error_format": attr.string(
+            default = "",
+            doc = "error-format flag for buf breaking: https://buf.build/docs/reference/cli/buf/breaking#error-format",
         ),
     },
     toolchains = [_TOOLCHAIN],

--- a/buf/internal/lint.bzl
+++ b/buf/internal/lint.bzl
@@ -29,6 +29,7 @@ def _buf_lint_test_impl(ctx):
     proto_infos = [t[ProtoInfo] for t in ctx.attr.targets]
     config = json.encode({
         "input_config": "" if ctx.file.config == None else ctx.file.config.short_path,
+        "error_format": ctx.attr.error_format,
     })
     files_to_include = []
     if ctx.file.config != None:
@@ -52,6 +53,10 @@ buf_lint_test = rule(
         "config": attr.label(
             allow_single_file = True,
             doc = "The `buf.yaml` file",
+        ),
+        "error_format": attr.string(
+            default = "",
+            doc = "error-format flag for buf lint: https://buf.build/docs/reference/cli/buf/lint#error-format",
         ),
     },
     toolchains = [_TOOLCHAIN],

--- a/examples/single_module/BUILD.bazel
+++ b/examples/single_module/BUILD.bazel
@@ -22,6 +22,7 @@ buf_breaking_test(
     # The Image file to check against.
     against = "testdata/image.bin",
     config = ":buf.yaml",
+    error_format = "json",
     # The proto_library targets to include.
     # Refer to the documentation for more on this: https://docs.buf.build/build-systems/bazel#buf-breaking-test
     targets = [

--- a/examples/single_module/bar/v1/BUILD.bazel
+++ b/examples/single_module/bar/v1/BUILD.bazel
@@ -25,4 +25,5 @@ buf_lint_test(
     name = "bar_proto_lint",
     config = "//:buf.yaml",
     targets = [":bar_proto"],
+    error_format = "config-ignore-yaml",
 )

--- a/examples/single_module/foo/v1/BUILD.bazel
+++ b/examples/single_module/foo/v1/BUILD.bazel
@@ -24,5 +24,5 @@ proto_library(
 buf_lint_test(
     name = "foo_proto_lint",
     config = "//:buf.yaml",
-    targets = [":foo_proto"],    
+    targets = [":foo_proto"],
 )

--- a/examples/single_module/foo/v1/BUILD.bazel
+++ b/examples/single_module/foo/v1/BUILD.bazel
@@ -24,5 +24,5 @@ proto_library(
 buf_lint_test(
     name = "foo_proto_lint",
     config = "//:buf.yaml",
-    targets = [":foo_proto"],
+    targets = [":foo_proto"],    
 )


### PR DESCRIPTION
Add support for `--error-format` of `buf breaking` and `buf lint`. Closes #19 