### PR TITLE
Support gazelle in bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,21 +1,35 @@
 "Bazel module definition for bzlmod"
 module(
     name = "rules_buf",
-    version = "0.0.0", # Replaced when publishing
+    version = "0.0.0",  # Replaced when publishing
     compatibility_level = 1,
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
+
 # Only needed because rules_proto doesn't provide the protoc toolchain yet.
 # TODO: remove in the future
 bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")
 
+bazel_dep(name = "rules_go", version = "0.42.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "bazel_skylib", version = "1.5.0")
+
 # We depend on gazelle at runtime to generate our proto_library rules
-bazel_dep(name = "gazelle", version = "0.33.0")
+bazel_dep(name = "gazelle", version = "0.34.0", repo_name = "bazel_gazelle")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+use_repo(
+    go_deps,
+    "com_github_bazelbuild_buildtools",
+    "com_github_stretchr_testify",
+    "in_gopkg_yaml_v3",
+)
 
 # ... and then reach inside to get the gazelle binary from this repository
-non_module_deps = use_extension("@gazelle//internal/bzlmod:non_module_deps.bzl", "non_module_deps")
+non_module_deps = use_extension("@bazel_gazelle//internal/bzlmod:non_module_deps.bzl", "non_module_deps")
 use_repo(non_module_deps, "bazel_gazelle_go_repository_tools")
 
 ext = use_extension("//buf:extensions.bzl", "buf")

--- a/buf/BUILD.bazel
+++ b/buf/BUILD.bazel
@@ -22,8 +22,8 @@ bzl_library(
     deps = [
         "//buf/internal:breaking",
         "//buf/internal:lint",
-        "//buf/internal:repo",
         "//buf/internal:push",
+        "//buf/internal:repo",
     ],
 )
 

--- a/buf/extensions.bzl
+++ b/buf/extensions.bzl
@@ -27,7 +27,6 @@ def _extension_impl(module_ctx):
     # Iterate over the global modules registered either directly by the user
     # or transitively by some other bazel module they use.
     for mod in module_ctx.modules:
-
         # collect all buf.dependency tags, group by name of resulting buf_dependencies repo
         for dependency in mod.tags.dependency:
             if dependency.name not in dependencies.keys():
@@ -44,7 +43,7 @@ def _extension_impl(module_ctx):
             if toolchains.name not in registrations.keys():
                 registrations[toolchains.name] = []
             registrations[toolchains.name].append(toolchains.version)
-    
+
     # Don't require that the user manually registers a toolchain
     if len(registrations) == 0:
         registrations = {_DEFAULT_TOOLCHAIN_NAME: [_DEFAULT_VERSION]}

--- a/examples/bzlmod/BUILD.bazel
+++ b/examples/bzlmod/BUILD.bazel
@@ -1,25 +1,39 @@
 load("@rules_buf//buf:defs.bzl", "buf_lint_test")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@gazelle//:def.bzl", "gazelle", "gazelle_binary")
 
-exports_files(["buf.yaml"], visibility = ["//visibility:public"])
+exports_files(
+    ["buf.yaml"],
+    visibility = ["//visibility:public"],
+)
 
-proto_library(
-    name = "unused",
-    srcs = ["unused.proto"],
+gazelle(
+    name = "gazelle",
+    gazelle = ":gazelle-buf",
+)
+
+gazelle_binary(
+    name = "gazelle-buf",
+    languages = [
+        "@gazelle//language/proto",  # Built-in rule from gazelle for Protos.
+        # Any languages that depend on Gazelle's proto plugin must come after it.
+        "@rules_buf//gazelle/buf:buf",  # Loads the Buf extension
+    ],
+    visibility = ["//visibility:public"],
 )
 
 proto_library(
-    name = "foo_proto",
-    srcs = ["file.proto"],
-    deps = [
-        # imports "validate/validate.proto"
-        "@buf_deps//validate:validate_proto",
-        ":unused",
+    name = "root_proto",
+    srcs = [
+        "file.proto",
+        "unused.proto",
     ],
+    visibility = ["//visibility:public"],
+    deps = ["@buf_deps//validate:validate_proto"],
 )
 
 buf_lint_test(
-    name = "foo_proto_lint",
-    targets = [":foo_proto"],
-    config = "buf.yaml",
+    name = "root_proto_lint",
+    config = "//:buf.yaml",
+    targets = [":root_proto"],
 )

--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -1,5 +1,6 @@
 "Bazel dependencies"
 bazel_dep(name = "rules_buf", dev_dependency = True, version = "0.0.0")
+bazel_dep(name = "gazelle", dev_dependency = True, version = "0.34.0")
 
 local_path_override(
     module_name = "rules_buf",


### PR DESCRIPTION
Support gazelle in bzlmod. #42 added support for bzlmod but it did not support the gazelle plugin, this updates the module file to support gazelle.