### PR TITLE
Release prep `v0.2.0`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "rules_buf",
-    version = "0.0.0",  # Replaced when publishing
+    version = "0.2.0",
     compatibility_level = 1,
 )
 

--- a/buf/defs.bzl
+++ b/buf/defs.bzl
@@ -28,11 +28,9 @@ Use [gazelle](/gazelle/buf) to auto generate all of these rules based on `buf.ya
 
 load("//buf/internal:breaking.bzl", _buf_breaking_test = "buf_breaking_test")
 load("//buf/internal:lint.bzl", _buf_lint_test = "buf_lint_test")
-load("//buf/internal:push.bzl", _buf_push = "buf_push")
 load("//buf/internal:repo.bzl", _buf_dependencies = "buf_dependencies")
 
 buf_dependencies = _buf_dependencies
-buf_push = _buf_push
 
 def buf_breaking_test(timeout = "short", **kwargs):
     _buf_breaking_test(timeout = timeout, **kwargs)


### PR DESCRIPTION
Release prep `v0.2.0`. Hides the unreleased `buf_push` rule. It can once we address https://github.com/bufbuild/rules_buf/issues/43