### PR TITLE
Skip generating `buf_push` rule

### DIFF
--- a/gazelle/buf/buf.go
+++ b/gazelle/buf/buf.go
@@ -80,6 +80,10 @@ type Config struct {
 	ModuleRoot bool
 	// BufConfigFile is for the nearest buf.yaml
 	BufConfigFile label.Label
+	// GeneratePushRule controls if buf_push should be generated.
+	//
+	// Always false for now.
+	GeneratePushRule bool
 }
 
 // BufModule is the parsed buf.yaml. It currently only supports version, name, and build

--- a/gazelle/buf/buf_test.go
+++ b/gazelle/buf/buf_test.go
@@ -58,6 +58,8 @@ func TestCrossResolve(t *testing.T) {
 }
 
 func TestPush(t *testing.T) {
+	// Skipping this test until we release the `buf_push` rule
+	t.SkipNow()
 	t.Parallel()
 	testRunGazelle(t, "push")
 }

--- a/gazelle/buf/generate.go
+++ b/gazelle/buf/generate.go
@@ -52,7 +52,7 @@ func (*bufLang) GenerateRules(args language.GenerateArgs) language.GenerateResul
 	}
 	if config.ModuleRoot {
 		protoImportPaths := getProtoImportPaths(config, args.Dir)
-		if config.Module.Name != "" {
+		if config.GeneratePushRule && config.Module.Name != "" {
 			pushRule := generatePushRule()
 			result.Gen = append(result.Gen, pushRule)
 			result.Imports = append(result.Imports, protoImportPaths)


### PR DESCRIPTION
Closes #51, before `v0.2.0` we choose to not export the `buf_push` rule but did not skip generating it via gazelle