### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-bazel-cache
       - uses: actions/checkout@v2
       - name: bazel test
-        run: bazel test --test_output=errors //...
+        run: make test
   macos:
     runs-on: macos-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
           key: ${{ runner.os }}-bazel-cache
       - uses: actions/checkout@v2
       - name: bazel test
-        run: bazel test --test_output=errors //...
+        run: make test
   windows:
     runs-on: windows-latest
     steps:
@@ -50,4 +50,4 @@ jobs:
           key: ${{ runner.os }}-bazel-cache
       - uses: actions/checkout@v2
       - name: bazel test
-        run: bazel test --test_output=errors  //...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clean: ## Delete intermediate build artifacts
 
 .PHONY: test
 test: ## Run unit tests
-	$(BAZEL) test //...
+	$(BAZEL) test --noenable_bzlmod //...
 
 .PHONY: generate
 generate: $(BIN)/license-header ## Regenerate code and licenses


### PR DESCRIPTION
Fix CI by disabling bzlmod for testing this repo. We support bzlmod to import and use the exported rules but th repo itself hasn't been migrated to bzlmod yet.