### PR TITLE
Add sha256 support for bzlmod case

### DIFF
--- a/buf/extensions.bzl
+++ b/buf/extensions.bzl
@@ -20,6 +20,7 @@ load("//buf/internal:toolchain.bzl", "buf_download_releases")
 load("//buf/internal:repo.bzl", "buf_dependencies")
 
 _DEFAULT_VERSION = "v1.28.1"
+_DEFAULT_SHA256 = "05dfb45d2330559d258e1230f5a25e154f0a328afda2a434348b5ba4c124ece7"
 _DEFAULT_TOOLCHAIN_NAME = "rules_buf_toolchains"
 _DEFAULT_DEPS = "buf_deps"
 
@@ -31,6 +32,7 @@ dependency = tag_class(attrs = {
 toolchains = tag_class(attrs = {
     "name": attr.string(doc = "name of resulting buf toolchains repo", default = _DEFAULT_TOOLCHAIN_NAME),
     "version": attr.string(doc = "Version of the buf tool, see https://github.com/bufbuild/buf/releases"),
+    "sha256": attr.string(doc = "The checksum sha256.txt file"),
 })
 
 def _extension_impl(module_ctx):
@@ -55,11 +57,11 @@ def _extension_impl(module_ctx):
                 """)
             if toolchains.name not in registrations.keys():
                 registrations[toolchains.name] = []
-            registrations[toolchains.name].append(toolchains.version)
+            registrations[toolchains.name].append({"version": toolchains.version, "sha256": toolchains.sha256})
 
     # Don't require that the user manually registers a toolchain
     if len(registrations) == 0:
-        registrations = {_DEFAULT_TOOLCHAIN_NAME: [_DEFAULT_VERSION]}
+        registrations = {_DEFAULT_TOOLCHAIN_NAME: [{"version": _DEFAULT_VERSION, "sha256": _DEFAULT_SHA256}]}
 
     for name, versions in registrations.items():
         if len(versions) > 1:
@@ -72,7 +74,8 @@ def _extension_impl(module_ctx):
             selected = versions[0]
         buf_download_releases(
             name = name,
-            version = selected,
+            version = selected["version"],
+            sha256 = selected["sha256"],
         )
 
     for name, modules in dependencies.items():


### PR DESCRIPTION
I started to use rules_rust, which uses rules_buf.
I also use bzlmod and download all dependencies ahead of time to support builds without internet access.

For this to work, all downloads from the internet need to provide sha256 hash in the download actions. I saw that for the WORKSPACE style usage, this already works (`buf_download_releases` already supports that).

This MR adds the correct hash for v1.28.1 and allows to also override the hash in addition to the version.