### PR TITLE
Release `0.3.0`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "rules_buf",
-    version = "0.2.0",
+    version = "0.3.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
## What's Changed
* Add `protoc_args` attribute to `buf_lint_test` and `buf_breaking_test` by @sushain97 in https://github.com/bufbuild/rules_buf/pull/50
* Get the os info from repo ctx by @kusaeva in https://github.com/bufbuild/rules_buf/pull/58
* Add sha256 support for bzlmod case by @adrianimboden in https://github.com/bufbuild/rules_buf/pull/61
* Add `module` option to `lint` and `breaking` rules by @srikrsna-buf in https://github.com/bufbuild/rules_buf/pull/65
* Add gazelle support for `v2` by @srikrsna-buf in https://github.com/bufbuild/rules_buf/pull/66
* Add support for multiple config files of different versions by @srikrsna-buf in https://github.com/bufbuild/rules_buf/pull/68

## New Contributors
* @chrispine made their first contribution in https://github.com/bufbuild/rules_buf/pull/56
* @kusaeva made their first contribution in https://github.com/bufbuild/rules_buf/pull/58
* @adrianimboden made their first contribution in https://github.com/bufbuild/rules_buf/pull/61

**Full Changelog**: https://github.com/bufbuild/rules_buf/compare/v0.2.0...v0.3.0