### PR TITLE
Setup https://github.com/bazel-contrib/publish-to-bcr

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,14 @@
+{
+    "homepage": "https://github.com/bufbuild/rules_buf",
+    "maintainers": [
+      {
+        "name": "Sri Krishna",
+        "github": "srikrsna-buf"
+      }
+    ],
+    "repository": [
+      "github:bufbuild/rules_buf"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "examples/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [6.x, 7.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "",
+    "strip_prefix": "{REPO}-{VERSION}",
+    "url": "https://github.com/{OWNER}/{REPO}/releases/download/{TAG}/{REPO}-{TAG}.tar.gz"
+}


### PR DESCRIPTION
Note, you'll also have to install the Publish to BCR app on this GH repo, and make a fork of the bazel-central-registry repo (for your PRs to originate from) and install the app there too