### PR TITLE
Fix running tests in Windows

### DIFF
--- a/buf/internal/breaking.bzl
+++ b/buf/internal/breaking.bzl
@@ -59,6 +59,9 @@ buf_breaking_test = rule(
             executable = True,
             cfg = "exec",
         ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
         "targets": attr.label_list(
             providers = [ProtoInfo],
             doc = """`proto_library` targets to check for breaking changes""",

--- a/buf/internal/lint.bzl
+++ b/buf/internal/lint.bzl
@@ -56,6 +56,9 @@ buf_lint_test = rule(
             executable = True,
             cfg = "exec",
         ),
+        "_windows_constraint": attr.label(
+            default = "@platforms//os:windows",
+        ),
         "targets": attr.label_list(
             providers = [ProtoInfo],
             mandatory = True,

--- a/buf/internal/toolchain.bzl
+++ b/buf/internal/toolchain.bzl
@@ -52,13 +52,13 @@ _buf_toolchain = rule(
 
 def declare_buf_toolchains(os, cpu, rules_buf_repo_name):
     for cmd in ["buf", "protoc-gen-buf-lint", "protoc-gen-buf-breaking"]:
-        exe_suffix = ""
+        cmd_suffix = ""
         if os == "windows":
-            exe_suffix = ".exe"
+            cmd_suffix = ".exe"
         toolchain_impl = cmd + "_toolchain_impl"
         _buf_toolchain(
             name = toolchain_impl,
-            cli = str(Label("//:"+ cmd + exe_suffix)),
+            cli = str(Label("//:"+ cmd + cmd_suffix)),
         )
         native.toolchain(
             name = cmd + "_toolchain",

--- a/buf/internal/toolchain.bzl
+++ b/buf/internal/toolchain.bzl
@@ -52,13 +52,13 @@ _buf_toolchain = rule(
 
 def declare_buf_toolchains(os, cpu, rules_buf_repo_name):
     for cmd in ["buf", "protoc-gen-buf-lint", "protoc-gen-buf-breaking"]:
-        ext = ""
+        exe_suffix = ""
         if os == "windows":
-            ext = ".exe"
+            exe_suffix = ".exe"
         toolchain_impl = cmd + "_toolchain_impl"
         _buf_toolchain(
             name = toolchain_impl,
-            cli = str(Label("//:"+ cmd)),
+            cli = str(Label("//:"+ cmd + exe_suffix)),
         )
         native.toolchain(
             name = cmd + "_toolchain",


### PR DESCRIPTION
This should resolve the toolchain registration issue from #78.

Also, it adds a batch script version of the shell script shim used to invoke protoc for tests; however, this requires `--enable_runfiles` to be explicitly passed or added to `.bazelrc` for a project, as Bazel on Windows does not populate runfiles by default.

In the future, we will need a better approach to supporting Windows that uses the runfiles manifest instead. This is tricky though, and will require some careful thought.