### PR TITLE
Add more complete test ignores

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -25,7 +25,7 @@ local_path_override(
 buf = use_extension("@rules_buf//buf:extensions.bzl", "buf")
 
 # Override the default version of buf
-buf.toolchains(version = "v1.26.0")
+buf.toolchains(version = "v1.31.0")
 
 # See https://buf.build/docs/build-systems/bazel#buf-dependencies
 buf.dependency(module = "buf.build/envoyproxy/protoc-gen-validate:eac44469a7af47e7839a7f1f3d7ac004")

--- a/examples/bzlmod/buf.yaml
+++ b/examples/bzlmod/buf.yaml
@@ -1,4 +1,8 @@
 version: v1
 lint:
   use:
+    - DEFAULT
+  allow_comment_ignores: true
+  except:
     - IMPORT_USED
+    - RPC_REQUEST_STANDARD_NAME

--- a/examples/bzlmod/file.proto
+++ b/examples/bzlmod/file.proto
@@ -16,3 +16,16 @@ syntax = "proto3";
 
 import "unused.proto";
 import "validate/validate.proto";
+
+message HttpBody {
+  string name = 1;
+}
+
+message Empty {}
+
+service HttpService {
+  // Receives an inbound message an http client.
+  // buf:lint:ignore RPC_RESPONSE_STANDARD_NAME
+  // buf:lint:ignore RPC_REQUEST_RESPONSE_UNIQUE
+  rpc ReceiveMessage (HttpBody) returns (Empty) {}
+}


### PR DESCRIPTION
Per #64, adds a slightly more complete example of how these rules might be used in the wild, including violations that require `allow_comment_ignores: true` to properly ignore. 

I suggest adding code like this to the example and adding some language on https://buf.build/docs/build-systems/bazel along the lines of:

> **Important:** `allow_comment_ignores: true` requires the bazel flag `--experimental_proto_descriptor_sets_include_source_info` in order to work. (for example `bazel test //:root_proto_lint --experimental_proto_descriptor_sets_include_source_info`)

Happy to do a PR for the doc update as well if someone can point me in the direction of that repo, if it exists (I couldn't find it easily myself).