### PR TITLE
Update bzlmod example to be able to use toolchain

### DIFF
--- a/examples/bzlmod/MODULE.bazel
+++ b/examples/bzlmod/MODULE.bazel
@@ -33,3 +33,5 @@ buf.dependency(module = "buf.build/acme/petapis:7abdb7802c8f4737a1a23a35ca8266ef
 
 # Allow references to labels under @buf_deps
 use_repo(buf, "buf_deps")
+# Allow people to use `bazel run @rules_buf_toolchains//:buf -- --version`
+use_repo(buf, "rules_buf_toolchains")


### PR DESCRIPTION
While playing around with this bazel module.
I was looking at this issue https://github.com/bufbuild/rules_buf/issues/38 
And when using the module example I wasn't able to use the bazel run cmd.
So this PR just aim to fix that.