### PR TITLE
Fix extensions.bzl to allow for multiple versions

### DIFF
--- a/buf/extensions.bzl
+++ b/buf/extensions.bzl
@@ -66,7 +66,7 @@ def _extension_impl(module_ctx):
     for name, versions in registrations.items():
         if len(versions) > 1:
             # TODO: should be semver-aware, using MVS
-            selected = sorted(versions, reverse = True)[0]
+            selected = sorted(versions, key = lambda v: v["version"], reverse = True)[0]
 
             # buildifier: disable=print
             print("NOTE: buf toolchains {} has multiple versions {}, selected {}".format(name, versions, selected))


### PR DESCRIPTION
Current code has a bug, where if there are multiple registration it will not run with error: 
```
Error in sorted: unsupported comparison: dict <=> dict
```