### PR TITLE
Add repository_url to reproducible attributes

### DIFF
--- a/buf/internal/toolchain.bzl
+++ b/buf/internal/toolchain.bzl
@@ -164,7 +164,8 @@ def _buf_download_releases_impl(ctx):
             rules_buf_repo_name = Label("//buf/repositories.bzl").workspace_name,
         ),
     )
-    return update_attrs(ctx.attr, ["version", "sha256"], {"version": version, "sha256": sha256})
+    attrs = {"version": version, "repository_url": repository_url, "sha256": sha256}
+    return update_attrs(ctx.attr, attrs.keys(), attrs)
 
 buf_download_releases = repository_rule(
     implementation = _buf_download_releases_impl,


### PR DESCRIPTION
When `repository_url` is used, bazel complains about reproducible form:

```
DEBUG: Rule 'rules_buf_toolchains' indicated that a canonical reproducible form can be obtained by dropping arguments ["repository_url"]
```

`repository_url` should be included in the attributes returned from the rule to indicate that it can also be used to generate reproducible form.