### PR TITLE
Bump actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Caches and restores the bazelisk download directory, the bazel build directory.
       - name: Cache bazel
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazelisk
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Caches and restores the bazelisk download directory, the bazel build directory.
       - name: Cache bazel
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/bazelisk
@@ -43,7 +43,7 @@ jobs:
   #   steps:
   #     # Caches and restores the bazelisk download directory, the bazel build directory.
   #     - name: Cache bazel
-  #       uses: actions/cache@v2
+  #       uses: actions/cache@v4
   #       with:
   #         path: |
   #           ~\AppData\Local\bazelisk


### PR DESCRIPTION
Bumps the actions/cache GitHub action from v2 to v4 to address the deprecation of v2: https://github.com/actions/cache/discussions/1510.