### PR TITLE
Release `0.4.0`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@
 
 module(
     name = "rules_buf",
-    version = "0.3.1",
+    version = "0.4.0",
     compatibility_level = 1,
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 16,
+  "lockFileVersion": 18,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -76,7 +76,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.16/source.json": "227e83737046aa4f50015da48e98e0d8ab42fd0ec74d8d653b6cc9f9a357f200",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
@@ -97,8 +98,8 @@
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
     "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
-    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
+    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
@@ -148,8 +149,8 @@
   "moduleExtensions": {
     "//buf:extensions.bzl%buf": {
       "general": {
-        "bzlTransitiveDigest": "YSEZH8GE9Vw6/4NxKTgq++eNm9wvynJWyefii6gfnLQ=",
-        "usagesDigest": "Cw1OZNQspwk0gValRUWb+UkhSqXg9WegCNZoQuRjLhY=",
+        "bzlTransitiveDigest": "J3ndkJEae/GVD6Qr72aEJKdi2NBcHniN24JaqUNAHgQ=",
+        "usagesDigest": "P6MNoK7+YdyjATQzCfPj1ZnMiSjxWBl0k0wsTntaCJY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -174,7 +175,7 @@
     "@@gazelle+//:extensions.bzl%go_deps": {
       "general": {
         "bzlTransitiveDigest": "nsDQnndMzdULQ+7W4lHxU3l/gbZHXSnFeUjfvmZ48o8=",
-        "usagesDigest": "8AHHp+01VLapHxZC+QKGuRlsPLHD3Nu5UalhvGpYsJg=",
+        "usagesDigest": "FTUdt/M19lpky9xUEiZzGu85bItPn5dtE+FIfM1EZLg=",
         "recordedFileInputs": {
           "@@//go.mod": "c96e5c352880a2df5cd7294265df91c7bad4fb24ef3865ccb1b9ceb29341cf8a",
           "@@//go.sum": "968d06e5d35e524686d63dda36b4fb82d5054a4c5a42a5da8214a43cc4e8edb3",
@@ -557,7 +558,7 @@
     "@@gazelle+//internal/bzlmod:non_module_deps.bzl%non_module_deps": {
       "general": {
         "bzlTransitiveDigest": "AjbsH9WZCj0ipLarbbkp25YBRrRhWYvO7OIiTcHyyok=",
-        "usagesDigest": "f3VzXb+dGPKxKkQuin/flCH4sGjHxJdjiCeEl15atHw=",
+        "usagesDigest": "rVuU30WGj2DmJE/SBQCsgRHmvrNvRi07lufFX85CxC8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -619,7 +620,7 @@
     },
     "@@rules_go+//go:extensions.bzl%go_sdk": {
       "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "dO8hGGpTWc27rkWJb+uMKqxLZQUvdp7kTxwhIbLYF8E=",
+        "bzlTransitiveDigest": "74tiWoxbNX3WvDTl1YSaCvWBVp7+H3jfMluBOXnHyrM=",
         "usagesDigest": "igIBXyqNg9Be63Cuu6kZxOeoDRDMqxSv8BcoWiqSh3w=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -697,7 +698,7 @@
     },
     "@@rules_go+//go/private:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "FN+C5TkJg7mYK7XM6e7VATfEgXdZBiIYOdJ87wauiwU=",
+        "bzlTransitiveDigest": "gjSR6TTB8u4GpWSu2g85GiwUJzIQueR54GN0E3srxJk=",
         "usagesDigest": "JL1XfI3Chd9vaoVGnIlNXDdHjWcf9WYe/Lu+A1HCC74=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -908,28 +909,6 @@
           ],
           [
             "rules_go+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
-    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
-      "general": {
-        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
-        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "compatibility_proxy": {
-            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_java+",
             "bazel_tools",
             "bazel_tools"
           ]


### PR DESCRIPTION
## What's Changed
* Use canonical_id in rctx.download and use the latest github release version by @Strum355 in https://github.com/bufbuild/rules_buf/pull/62
* Fix running tests in Windows by @jchadwick-buf in https://github.com/bufbuild/rules_buf/pull/79
* Update bzlmod example to be able to use toolchain by @sfroment in https://github.com/bufbuild/rules_buf/pull/81
* Fix extensions.bzl to allow for multiple versions by @filippobrizzi in https://github.com/bufbuild/rules_buf/pull/88
* Add repository_url to reproducible attributes by @styurin in https://github.com/bufbuild/rules_buf/pull/94
* Sort targets in the buf_breaking rules by @dspencer12 in https://github.com/bufbuild/rules_buf/pull/100
* Add `buf_format` rule by @srikrsna-buf in https://github.com/bufbuild/rules_buf/pull/105

## New Contributors
* @Strum355 made their first contribution in https://github.com/bufbuild/rules_buf/pull/62
* @jchadwick-buf made their first contribution in https://github.com/bufbuild/rules_buf/pull/79
* @sfroment made their first contribution in https://github.com/bufbuild/rules_buf/pull/81
* @filippobrizzi made their first contribution in https://github.com/bufbuild/rules_buf/pull/88
* @dspencer12 made their first contribution in https://github.com/bufbuild/rules_buf/pull/101
* @styurin made their first contribution in https://github.com/bufbuild/rules_buf/pull/94

**Full Changelog**: https://github.com/bufbuild/rules_buf/compare/v0.3.0...v0.4.0