### PR TITLE
Add release templates

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://github.com/bufbuild/rules_buf",
+  "maintainers": [
+    {
+      "name": "Buf Team",
+      "email": "bcr-github@buf.build",
+      "github": "bcr-buf"
+    }
+  ],
+  "repository": ["github:bufbuild/rules_buf"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "examples/bzlmod"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    bazel: [7.x, 8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}


### PR DESCRIPTION
Add release templates for automating publishing to BCR. The [release process](https://github.com/bazel-contrib/publish-to-bcr/?tab=readme-ov-file#setup) was updated to use workflow, will be added as a close followup.