### PR TITLE
Add ppc64le to list of supported cpu architecutres

### DIFF
--- a/buf/internal/toolchain.bzl
+++ b/buf/internal/toolchain.bzl
@@ -112,7 +112,7 @@ def _buf_download_releases_impl(ctx):
         version = json.decode(version_data)["name"]
 
     os, cpu = _detect_host_platform(ctx)
-    if os not in ["linux", "darwin", "windows"] or cpu not in ["arm64", "amd64"]:
+    if os not in ["linux", "darwin", "windows"] or cpu not in ["arm64", "amd64", "ppc64le"]:
         fail("Unsupported operating system or cpu architecture ")
     if os == "linux" and cpu == "arm64":
         cpu = "aarch64"


### PR DESCRIPTION
As of v1.54.0, buf supports releases for the ppc64le architecture. Add ppc64le to the list of supported cpu architectures in the buf bazel toolchain.