### PR TITLE
pass in the repo root for the 'dir' argument

### DIFF
--- a/buf/internal/repo.bzl
+++ b/buf/internal/repo.bzl
@@ -71,6 +71,7 @@ def _buf_dependencies_impl(ctx):
         "fix",
         "-repo_root",
         ctx.path(""),
+        ctx.path(""),
     ]
     res = ctx.execute(cmd, quiet = False)
     if res.return_code != 0:


### PR DESCRIPTION
In tools that run bazel commands from within `bazel run` the `BUILD_WORKSPACE_DIRECTORY` will be set and then in this [code](https://github.com/bazel-contrib/bazel-gazelle/blob/master/cmd/gazelle/fix-update.go#L122-L139) the directory will eventually be set to the top level repo root.  An example of a tool that this can happen to is the [gopackagesdriver](https://github.com/bazel-contrib/rules_go/wiki/Editor-setup) in rules_go.

This results in error messages like:
```
 no such package '@@rules_buf++buf+buf_deps//buf/validate': failed with code: 1, error: gazelle: .: not a subdirectory of repo root
```

By passing in additional argument it explicitly sets the `dir` to the directory of the repo. Gazelle itself does something [similar](https://github.com/bazel-contrib/bazel-gazelle/blob/6803436a9c39209bd56ea1dba2dddda323a3c98b/internal/go_repository.bzl#L363) 