### PR TITLE
Remove Windows from BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "examples/bzlmod"
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["debian10", "macos", "ubuntu2004"]
     bazel: [7.x, 8.x]
   tasks:
     run_tests:


### PR DESCRIPTION
Windows doesn't actually pass presubmits, so this is just a lie. I would love to fix it, but it's more important to get another release out with the new workflow first.

This is caused by #120 which we should try to rectify sometime...