### PR TITLE
Add s390x to list of supported cpu architecutres

### DIFF
--- a/buf/internal/toolchain.bzl
+++ b/buf/internal/toolchain.bzl
@@ -119,13 +119,15 @@ def _buf_download_releases_impl(ctx):
     major_version = int(version_number[0])
     minor_version = int(version_number[1])
     os, cpu = _detect_host_platform(ctx)
-    if os not in ["linux", "darwin", "windows"] or cpu not in ["arm64", "amd64", "ppc64le"]:
+    if os not in ["linux", "darwin", "windows"] or cpu not in ["arm64", "amd64", "ppc64le", "s390x"]:
         fail("Unsupported operating system or cpu architecture ")
     if os == "linux" and cpu == "arm64":
         cpu = "aarch64"
     if cpu == "amd64":
         cpu = "x86_64"
     if cpu == "ppc64le" and (major_version < 1 or (major_version == 1 and minor_version < 54)):
+        fail("Unsupported operating system or cpu architecture ")
+    if cpu == "s390x" and (major_version < 1 or (major_version == 1 and minor_version < 56)):
         fail("Unsupported operating system or cpu architecture ")
 
     ctx.report_progress("Downloading buf release hash")


### PR DESCRIPTION
Buf added support for s390x in 1.56. I would like to add s390x support to rules_buf for this version or greater.