### PR TITLE
fix(gazelle): generate target names from proto file name, not directory

### DIFF
--- a/gazelle/buf/cross_resolve.go
+++ b/gazelle/buf/cross_resolve.go
@@ -16,10 +16,10 @@ package buf
 
 import (
 	"path"
+	"strings"
 
 	"github.com/bazelbuild/bazel-gazelle/config"
 	"github.com/bazelbuild/bazel-gazelle/label"
-	"github.com/bazelbuild/bazel-gazelle/language/proto"
 	"github.com/bazelbuild/bazel-gazelle/resolve"
 )
 
@@ -46,9 +46,15 @@ func (*bufLang) CrossResolve(gazelleConfig *config.Config, ruleIndex *resolve.Ru
 	// Fall back to default buf_deps resolution
 	config := GetConfigForGazelleConfig(gazelleConfig)
 	depRepo := getRepoNameForPath(config.BufConfigFile.Pkg)
+
+	// Generate target name from the proto file name, not the directory name
+	// e.g., "nmts/v1/proto/ek/logical/interface.proto" -> "interface_proto"
+	protoFile := path.Base(importSpec.Imp)
+	targetName := strings.TrimSuffix(protoFile, ".proto") + "_proto"
+
 	return []resolve.FindResult{
 		{
-			Label: label.New(depRepo, path.Dir(importSpec.Imp), proto.RuleName(path.Dir(importSpec.Imp))),
+			Label: label.New(depRepo, path.Dir(importSpec.Imp), targetName),
 		},
 	}
 }


### PR DESCRIPTION
This PR stacks on top of !127 but I've split them as the rationale is different / you might not agree with both (let me know!).  The issue of this PR was uncovered in !127 fix of #117.  This PR Plus !127 resolve at least the base case issues of #117.

Fix target name generation in the buf gazelle plugin's `CrossResolve` function to use the proto file name instead of the directory name. This aligns with the official Bazel proto_library naming convention documented at: https://bazel.build/reference/be/protocol-buffer

Per Bazel's convention: "A file named foo.proto will be in a rule named foo_proto, which is located in the same package."

The original code used `proto.RuleName(path.Dir(importSpec.Imp))` which incorrectly derived target names from the directory path.

Example import: `logical/interface.proto`
  Before (wrong): `@buf_deps//logical:logical_proto` (from directory)
  After (correct): `@buf_deps//logical:interface_proto` (from file)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>