### PR TITLE
Guard against nil proto config in loadConfig

### DIFF
--- a/gazelle/buf/config.go
+++ b/gazelle/buf/config.go
@@ -113,17 +113,21 @@ func loadConfig(gazelleConfig *config.Config, packageRelativePath string, file *
 	// Here we set the config if the directive is not present
 	if config.ModuleRoot && packageRelativePath != "" {
 		protoConfig := proto.GetProtoConfig(gazelleConfig)
-		stripImportPrefix := "/" + packageRelativePath
-		if protoConfig.StripImportPrefix == "" {
-			protoConfig.StripImportPrefix = stripImportPrefix
-		}
-		if protoConfig.StripImportPrefix != stripImportPrefix {
-			log.Printf(
-				"strip_import_prefix at %s should be %s but is %s",
-				packageRelativePath,
-				stripImportPrefix,
-				protoConfig.StripImportPrefix,
-			)
+		if protoConfig == nil {
+			log.Print("buf: proto language is not enabled; skipping strip_import_prefix configuration")
+		} else {
+			stripImportPrefix := "/" + packageRelativePath
+			if protoConfig.StripImportPrefix == "" {
+				protoConfig.StripImportPrefix = stripImportPrefix
+			}
+			if protoConfig.StripImportPrefix != stripImportPrefix {
+				log.Printf(
+					"strip_import_prefix at %s should be %s but is %s",
+					packageRelativePath,
+					stripImportPrefix,
+					protoConfig.StripImportPrefix,
+				)
+			}
 		}
 	}
 	if file == nil {


### PR DESCRIPTION
## Summary

`proto.GetProtoConfig()` returns nil when the proto Gazelle language is not loaded alongside buf. This causes a nil pointer dereference panic in `loadConfig` at `gazelle/buf/config.go:117`.

This can happen when using `aspect_gazelle_prebuilt` (or any Gazelle binary) with `buf` enabled but `proto` not in the languages list.

## Fix

Guard the `proto.GetProtoConfig()` return value with a nil check. When nil, log a message and skip the `strip_import_prefix` configuration.

Fixes #147